### PR TITLE
Change key type from symbol to string

### DIFF
--- a/lib/fluent/plugin/in_sqs.rb
+++ b/lib/fluent/plugin/in_sqs.rb
@@ -48,12 +48,12 @@ module Fluent
           sleep @receive_interval
           @queue.receive_message do |message|
             record = {}
-            record[:body] = message.body.to_s
-            record[:handle] = message.handle.to_s
-            record[:id] = message.id.to_s
-            record[:md5] = message.md5.to_s
-            record[:url] = message.queue.url.to_s
-            record[:sender_id] = message.sender_id.to_s
+            record['body'] = message.body.to_s
+            record['handle'] = message.handle.to_s
+            record['id'] = message.id.to_s
+            record['md5'] = message.md5.to_s
+            record['url'] = message.queue.url.to_s
+            record['sender_id'] = message.sender_id.to_s
 
             Engine.emit(@tag, Time.now.to_i, record)
           end

--- a/spec/lib/fluent/plugin/in_sqs_spec.rb
+++ b/spec/lib/fluent/plugin/in_sqs_spec.rb
@@ -45,27 +45,27 @@ describe do
   
   describe 'emit' do
     let(:message) do
-      { :body => 'body',
-        :handle => 'handle',
-        :id => 'id',
-        :md5 => 'md5',
-        :url => 'url',
-        :sender_id => 'sender_id'
+      { 'body' => 'body',
+        'handle' => 'handle',
+        'id' => 'id',
+        'md5' => 'md5',
+        'url' => 'url',
+        'sender_id' => 'sender_id'
       }
     end
     let(:emmits) {
-      stub(Time).now {0}
+      allow(Time).to receive(:now).and_return(0)
 
       class AWS::SQS::Queue
         def receive_message
           yield OpenStruct.new(
-            { :body => 'body',
-              :handle => 'handle',
-              :id => 'id',
-              :md5 => 'md5',
-              :queue => OpenStruct.new(:url => 'url'),
-              :sender_id => 'sender_id',
-              :sent_at => 0
+            { 'body' => 'body',
+              'handle' => 'handle',
+              'id' => 'id',
+              'md5' => 'md5',
+              'queue' => OpenStruct.new(:url => 'url'),
+              'sender_id' => 'sender_id',
+              'sent_at' => 0
             })
         end
       end


### PR DESCRIPTION
現状、fluent-plugin-sqs は record の key を :body のようなシンボルで emit していますが、これだと他のプラグインと連携させることが難しいため、文字列に変更していただくことは可能でしょうか？

例えば、SQS に JSON を送信して、[fluent-plugin-parser](https://github.com/tagomoris/fluent-plugin-parser) で parse させようとして、以下の様な設定をしてもうまく動きません。

```
<source>
  type sqs
  sqs_url https://xxx
  tag sqs
</source>

<match sqs>
  type parser
  tag debug.y
  key_name body
  format json
</match>
```

これは[ここ](https://github.com/tagomoris/fluent-plugin-parser/blob/master/lib/fluent/plugin/out_parser.rb#L70) で `record[@key_name]` のようにして値を取り出すのですが、 config で指定した "body" は文字列なので、シンボルとマッチせずに値が取り出せません。また、config でシンボルを書く方法も現状ありません。

Fluentd コミッタの @sonots さんも[このように](https://twitter.com/hakobera/status/530371362196439041) に言っていたので、他のプラグインと組み合わせやすいように key をシンボルから文字列に変更するプルリクエストを書いてみました。

ただし、fluent-plugin-sqs としては大きな仕様変更になってしまうので、どうしても無理という場合は独自にフィルターを書いて回避することにします。

以上、よろしくご検討お願いします。
