### PR TITLE
Add max_number_of_messages parameter

### DIFF
--- a/lib/fluent/plugin/in_sqs.rb
+++ b/lib/fluent/plugin/in_sqs.rb
@@ -15,6 +15,7 @@ module Fluent
     config_param :sqs_endpoint, :string, :default => 'sqs.ap-northeast-1.amazonaws.com'
     config_param :sqs_url, :string
     config_param :receive_interval, :time, :default => 1
+    config_param :max_number_of_messages, :integer, :default => 1
 
     def configure(conf)
       super
@@ -46,7 +47,7 @@ module Fluent
       until @finished
         begin
           sleep @receive_interval
-          @queue.receive_message do |message|
+          @queue.receive_message(:limit => @max_number_of_messages) do |message|
             record = {}
             record['body'] = message.body.to_s
             record['handle'] = message.handle.to_s

--- a/spec/lib/fluent/plugin/in_sqs_spec.rb
+++ b/spec/lib/fluent/plugin/in_sqs_spec.rb
@@ -14,6 +14,7 @@ describe do
          aws_sec_key AWS_SEC_KEY
          tag     TAG
          sqs_url SQS_URL
+         max_number_of_messages 10
       ]
     }
     
@@ -41,6 +42,11 @@ describe do
       subject {instance.receive_interval}
       it{should == 1}
     end
+
+    context do
+      subject {instance.max_number_of_messages}
+      it{should == 10}
+    end
   end
   
   describe 'emit' do
@@ -57,7 +63,7 @@ describe do
       allow(Time).to receive(:now).and_return(0)
 
       class AWS::SQS::Queue
-        def receive_message
+        def receive_message(opts)
           yield OpenStruct.new(
             { 'body' => 'body',
               'handle' => 'handle',
@@ -69,11 +75,13 @@ describe do
             })
         end
       end
+      expect_any_instance_of(AWS::SQS::Queue).to receive(:receive_message).with({:limit => 10}).at_least(:once).and_call_original
+
       d = driver
       d.run do
         sleep 2
       end
-      
+
       d.emits
     }
 
@@ -84,6 +92,7 @@ describe do
            aws_sec_key AWS_SEC_KEY
            tag     TAG
            sqs_url SQS_URL
+           max_number_of_messages 10
         ]
       }
 


### PR DESCRIPTION
Add `max_number_of_messages` parameter to control maximum number of messages to receive.
Tuning this parameter can be improve message fetch performance.

This parameter is optional, and default value is not changed. So current user does not have to change their configuration.

http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/SQS/Queue.html#receive_message-instance_method
