### PR TITLE
Added create queue option, and no longer catching errors when sending records to sqs.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,6 +32,7 @@ Read events from from amazon SQS.
 
       # following attibutes are optional
     　
+      create_queue {boolean}
       sqs_endpoint {endpointURL}
 
       ### endpoint list ###
@@ -47,6 +48,7 @@ Read events from from amazon SQS.
 
       include_tag {boolean}
       tag_property_name {tag's property name in json}
+
 
     </match>
 

--- a/lib/fluent/plugin/out_sqs.rb
+++ b/lib/fluent/plugin/out_sqs.rb
@@ -57,11 +57,7 @@ module Fluent
             records = []
             chunk.msgpack_each {|record| records << { :message_body => record.to_json, :delay_seconds => @delay_seconds } }
             until records.length <= 0 do
-                begin
-                    @queue.batch_send(records.slice!(0..9))
-                rescue => e
-                    $stderr.puts e
-                end
+                @queue.batch_send(records.slice!(0..9))
             end
         end
     end

--- a/lib/fluent/plugin/out_sqs.rb
+++ b/lib/fluent/plugin/out_sqs.rb
@@ -15,11 +15,11 @@ module Fluent
         config_param :aws_key_id, :string, :default => nil
         config_param :aws_sec_key, :string, :default => nil
         config_param :queue_name, :string
+        config_param :create_queue, :bool, :default => true
         config_param :sqs_endpoint, :string, :default => 'sqs.ap-northeast-1.amazonaws.com'
         config_param :delay_seconds, :integer, :default => 0
         config_param :include_tag, :bool, :default => true
         config_param :tag_property_name, :string, :default => '__tag'
-        #config_param :buffer_queue_limit, :integer, :default => 10
 
         def configure(conf)
             super
@@ -34,8 +34,11 @@ module Fluent
 
             @sqs = AWS::SQS.new(
                 :sqs_endpoint => @sqs_endpoint)
-            @queue = @sqs.queues.create(@queue_name)
-
+            if @create_queue then
+                @queue = @sqs.queues.create(@queue_name)
+            else
+                @queue = @sqs.queues.named(@queue_name)
+            end
         end
 
         def shutdown


### PR DESCRIPTION
Two small changes:

1. Adds the create_queue option (default: true). Default behavior is the same as before. If set to false, the output plugin will use `@sqs.queues.named` to access the queue, then send messages to it. This could be useful if you have permissions to write to queues, but not to create queues.

2. Removed the error handling around the call to send stuff to the queue. This allows you to take advantage of BufferedOutput's reliability mechanisms: https://github.com/fluent/fluentd/blob/master/lib/fluent/output.rb#L182