### PR TITLE
Add depedency test-unit >= 3.0.0

### DIFF
--- a/fluent-plugin-sqs.gemspec
+++ b/fluent-plugin-sqs.gemspec
@@ -49,4 +49,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rr"
   s.add_development_dependency "pry"
   s.add_development_dependency "jeweler"
+  s.add_development_dependency "test-unit", ">= 3.0.0"
 end


### PR DESCRIPTION
Because Ruby 2.2 has a unit-test breaking change which is provided from Ruby itself.
This PR resolves this breaking change.

In more detail, please read this blog article section(Japanese):
http://www.clear-code.com/blog/2014/11/6.html#Ruby+2.2.E6.99.82.E4.BB.A3