### PR TITLE
Add secret parameters

### DIFF
--- a/lib/fluent/plugin/in_sqs.rb
+++ b/lib/fluent/plugin/in_sqs.rb
@@ -9,8 +9,8 @@ module Fluent
       super
     end
 
-    config_param :aws_key_id, :string, :default => nil
-    config_param :aws_sec_key, :string, :default => nil
+    config_param :aws_key_id, :string, :default => nil, :secret => true
+    config_param :aws_sec_key, :string, :default => nil, :secret => true
     config_param :tag, :string
     config_param :sqs_endpoint, :string, :default => 'sqs.ap-northeast-1.amazonaws.com'
     config_param :sqs_url, :string

--- a/lib/fluent/plugin/out_sqs.rb
+++ b/lib/fluent/plugin/out_sqs.rb
@@ -12,8 +12,8 @@ module Fluent
         include SetTimeKeyMixin
         config_set_default :include_time_key, true
 
-        config_param :aws_key_id, :string, :default => nil
-        config_param :aws_sec_key, :string, :default => nil
+        config_param :aws_key_id, :string, :default => nil, :secret => true
+        config_param :aws_sec_key, :string, :default => nil, :secret => true
         config_param :queue_name, :string
         config_param :create_queue, :bool, :default => true
         config_param :sqs_endpoint, :string, :default => 'sqs.ap-northeast-1.amazonaws.com'


### PR DESCRIPTION
Fluentd's config_params now supports concealing given parameters with xxxxxx.
If using fluentd dose not provide this concealing feature, it will be simply ignored.

So, currently simply ignored this parameter.
I'll send another pull request to bump up fluentd dependency to 0.12.x soon.