### PR TITLE
Bump up fluentd dependency 0.12.x

### DIFF
--- a/fluent-plugin-sqs.gemspec
+++ b/fluent-plugin-sqs.gemspec
@@ -30,16 +30,16 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<fluentd>, ["~> 0.10.0"])
+      s.add_runtime_dependency(%q<fluentd>, ["~> 0.12.0"])
       s.add_runtime_dependency(%q<aws-sdk>, ["~> 1.9.5"])
       s.add_runtime_dependency(%q<yajl-ruby>, ["~> 1.0"])
     else
-      s.add_dependency(%q<fluentd>, ["~> 0.10.0"])
+      s.add_dependency(%q<fluentd>, ["~> 0.12.0"])
       s.add_dependency(%q<aws-sdk>, ["~> 1.9.5"])
       s.add_dependency(%q<yajl-ruby>, ["~> 1.0"])
     end
   else
-    s.add_dependency(%q<fluentd>, ["~> 0.10.0"])
+    s.add_dependency(%q<fluentd>, ["~> 0.12.0"])
     s.add_dependency(%q<aws-sdk>, ["~> 1.9.5"])
     s.add_dependency(%q<yajl-ruby>, ["~> 1.0"])
   end

--- a/spec/lib/fluent/plugin/in_sqs_spec.rb
+++ b/spec/lib/fluent/plugin/in_sqs_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe do
   let(:driver) {
     AWS.stub!
+    Fluent::Test.setup
     Fluent::Test::InputTestDriver.new(Fluent::SQSInput).configure(config)
   }
   let(:instance) {driver.instance}


### PR DESCRIPTION
I'm not sure why this repository depends fluentd 0.10.x, but I bumped up fluentd dependency to 0.12.x.

Also I fixed test_helper to fix following errors:

```log
     Failure/Error: Fluent::Test::InputTestDriver.new(Fluent::SQSInput).configure(config)
     NoMethodError:
       undefined method `event_router' for nil:NilClass
     # ./vendor/bundle/ruby/2.1.0/gems/fluentd-0.12.12/lib/fluent/test/base.rb:48:in `initialize'
     # ./vendor/bundle/ruby/2.1.0/gems/fluentd-0.12.12/lib/fluent/test/input_test.rb:28:in `initialize'
     # ./spec/lib/fluent/plugin/in_sqs_spec.rb:7:in `new'
     # ./spec/lib/fluent/plugin/in_sqs_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/lib/fluent/plugin/in_sqs_spec.rb:9:in `block (2 levels) in <top (required)>'
     # ./spec/lib/fluent/plugin/in_sqs_spec.rb:48:in `block (4 levels) in <top (required)>'
     # ./spec/lib/fluent/plugin/in_sqs_spec.rb:49:in `block (4 levels) in <top (required)>'
```

NOTE:
I confirmed this pull request with Ruby 2.1.6 without test-unit and 2.2.1 with test-unit 3.1.2.
After [add dependency for test-unit 3.0 or later PR](https://github.com/ixixi/fluent-plugin-sqs/pull/15) is merged, also all tests will pass with Ruby 2.2.

And after this PR is merged, [adding secret parameters PR](https://github.com/ixixi/fluent-plugin-sqs/pull/16) feature will start to work! 