### PR TITLE
Don't send batches larger than total allowed SQS message size

### DIFF
--- a/lib/fluent/plugin/out_sqs.rb
+++ b/lib/fluent/plugin/out_sqs.rb
@@ -2,8 +2,10 @@ module Fluent
 
     require 'aws-sdk'
 
-    class SQSOutput < BufferedOutput
+    SQS_BATCH_SEND_MAX_MSGS = 10
+    SQS_BATCH_SEND_MAX_SIZE = 262144
 
+    class SQSOutput < BufferedOutput
         Fluent::Plugin.register_output('sqs', self)
 
         include SetTagKeyMixin
@@ -54,10 +56,34 @@ module Fluent
         end
 
         def write(chunk)
-            records = []
-            chunk.msgpack_each {|record| records << { :message_body => Yajl.dump(record), :delay_seconds => @delay_seconds } }
-            until records.length <= 0 do
-                @queue.batch_send(records.slice!(0..9))
+            batch_records = []
+            batch_size = 0
+            send_batches = [batch_records]
+
+            chunk.msgpack_each do |record|
+                body = Yajl.dump(record)
+                batch_size += body.bytesize
+                if batch_size > SQS_BATCH_SEND_MAX_SIZE ||
+                        batch_records.length >= SQS_BATCH_SEND_MAX_MSGS then
+                    batch_records = []
+                    batch_size = body.bytesize
+                    send_batches << batch_records
+                end
+
+                if batch_size > SQS_BATCH_SEND_MAX_SIZE then
+                    log.warn "Could not push message to SQS, payload exceeds "\
+                        "#{SQS_BATCH_SEND_MAX_SIZE} bytes.  "\
+                        "(Truncated message: #{body[0..200]})"
+                else
+                    batch_records << { :message_body => body, :delay_seconds => @delay_seconds }
+                end
+            end
+
+            until send_batches.length <= 0 do
+                records = send_batches.shift
+                until records.length <= 0 do
+                    @queue.batch_send(records.slice!(0..9))
+                end
             end
         end
     end


### PR DESCRIPTION
Saner handling for large messages: don't attempt to batch more messages than SQS allows and log warnings on single messages that exceed the allowed size to facilitate continued processing of other messages.