### PR TITLE
SQS Long Polling plus a few other tweaks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -44,7 +44,7 @@ Read events from from amazon SQS.
       # EU-West (Ireland)              : sqs.eu-west-1.amazonaws.com
       # South America (São Paulo)      : sns.sa-east-1.amazonaws.com
 
-      delay_seconds {delivery_deley_seconds}
+      delay_seconds {delivery_delay_seconds}
 
       include_tag {boolean}
       tag_property_name {tag's property name in json}
@@ -81,6 +81,10 @@ Read events from from amazon SQS.
       # South America (São Paulo)      : sns.sa-east-1.amazonaws.com
 
       receive_interval {receive_interval_seconds}
+
+      max_number_of_messages {max_number_of_messages}
+
+      wait_time_seconds {receive_message_wait_time_seconds}
 
     </source>
 

--- a/lib/fluent/plugin/in_sqs.rb
+++ b/lib/fluent/plugin/in_sqs.rb
@@ -14,8 +14,9 @@ module Fluent
     config_param :tag, :string
     config_param :sqs_endpoint, :string, :default => 'sqs.ap-northeast-1.amazonaws.com'
     config_param :sqs_url, :string
-    config_param :receive_interval, :time, :default => 1
-    config_param :max_number_of_messages, :integer, :default => 1
+    config_param :receive_interval, :time, :default => 0.1
+    config_param :max_number_of_messages, :integer, :default => 10
+    config_param :wait_time_seconds, :integer, :default => 10
 
     def configure(conf)
       super
@@ -47,7 +48,10 @@ module Fluent
       until @finished
         begin
           sleep @receive_interval
-          @queue.receive_message(:limit => @max_number_of_messages) do |message|
+          @queue.receive_message(
+            :limit => @max_number_of_messages,
+            :wait_time_seconds => @wait_time_seconds
+          ) do |message|
             record = {}
             record['body'] = message.body.to_s
             record['handle'] = message.handle.to_s

--- a/spec/lib/fluent/plugin/in_sqs_spec.rb
+++ b/spec/lib/fluent/plugin/in_sqs_spec.rb
@@ -42,7 +42,7 @@ describe do
 
     context do
       subject {instance.receive_interval}
-      it{should == 1}
+      it{should == 0.1}
     end
 
     context do
@@ -82,7 +82,7 @@ describe do
             })
         end
       end
-      expect_any_instance_of(AWS::SQS::Queue).to receive(:receive_message).with({:limit => 10}).at_least(:once).and_call_original
+      expect_any_instance_of(AWS::SQS::Queue).to receive(:receive_message).with({:limit => 10, :wait_time_seconds=>10}).at_least(:once).and_call_original
 
       d = driver
       d.run do

--- a/spec/lib/fluent/plugin/in_sqs_spec.rb
+++ b/spec/lib/fluent/plugin/in_sqs_spec.rb
@@ -16,6 +16,7 @@ describe do
          tag     TAG
          sqs_url SQS_URL
          max_number_of_messages 10
+         wait_time_seconds 10
       ]
     }
     
@@ -46,6 +47,11 @@ describe do
 
     context do
       subject {instance.max_number_of_messages}
+      it{should == 10}
+    end
+
+    context do
+      subject {instance.wait_time_seconds}
       it{should == 10}
     end
   end
@@ -94,6 +100,7 @@ describe do
            tag     TAG
            sqs_url SQS_URL
            max_number_of_messages 10
+           wait_time_seconds 10
         ]
       }
 


### PR DESCRIPTION
- added SQS Long Polling (enabled by default with wait_time_seconds = 10s)

http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html

- reduced receive_interval default to 0.1 given the above (maybe 0 would
  be better?)

- documented max_number_of_messages in README.rdoc

- increased max_number_of_messages default to 10 to match out_sqs.rb