### PR TITLE
Explicitly set dependency to AWS v1

### DIFF
--- a/lib/fluent/plugin/in_sqs.rb
+++ b/lib/fluent/plugin/in_sqs.rb
@@ -1,6 +1,6 @@
 module Fluent
 
-  require 'aws-sdk'
+  require 'aws-sdk-v1'
 
   class SQSInput < Input
     Plugin.register_input('sqs', self)

--- a/lib/fluent/plugin/out_sqs.rb
+++ b/lib/fluent/plugin/out_sqs.rb
@@ -1,6 +1,6 @@
 module Fluent
 
-    require 'aws-sdk'
+    require 'aws-sdk-v1'
 
     SQS_BATCH_SEND_MAX_MSGS = 10
     SQS_BATCH_SEND_MAX_SIZE = 262144


### PR DESCRIPTION
The latest `td-agent` package comes with AWS v1 and v2 libraries but it uses v2 by default which is not compatible.

Explicitly use AWS SDK v1 until the code is changed to use v2 and older fluentd versions are no longer around.