### PR TITLE
fix gemspec. aws-sdk => aws-sdk-v1.

### DIFF
--- a/fluent-plugin-sqs.gemspec
+++ b/fluent-plugin-sqs.gemspec
@@ -32,16 +32,16 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<fluentd>, ["~> 0.12.0"])
-      s.add_runtime_dependency(%q<aws-sdk>, ["~> 1.9.5"])
+      s.add_runtime_dependency(%q<aws-sdk-v1>)
       s.add_runtime_dependency(%q<yajl-ruby>, ["~> 1.0"])
     else
       s.add_dependency(%q<fluentd>, ["~> 0.12.0"])
-      s.add_dependency(%q<aws-sdk>, ["~> 1.9.5"])
+      s.add_dependency(%q<aws-sdk-v1>)
       s.add_dependency(%q<yajl-ruby>, ["~> 1.0"])
     end
   else
     s.add_dependency(%q<fluentd>, ["~> 0.12.0"])
-    s.add_dependency(%q<aws-sdk>, ["~> 1.9.5"])
+    s.add_dependency(%q<aws-sdk-v1>)
     s.add_dependency(%q<yajl-ruby>, ["~> 1.0"])
   end
   s.add_development_dependency "bundler"


### PR DESCRIPTION
Hello.

fix gemspec aws-sdk => aws-sdk-v1.

I use td-agent --gemfile option.
td-agent-2.3.1 include aws-sdk V2(fluent-plugin-s3 use).

So bundler conflict version aws-sdk.
