### PR TITLE
Tweak depenpendcy and specs exection settings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,8 @@ require 'rake'
 require 'rake/testtask'
 require 'rake/clean'
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
-Rake::TestTask.new(:test) do |t|
-  t.test_files = Dir['test/*_test.rb']
-  t.ruby_opts = ['-rubygems'] if defined? Gem
-  t.ruby_opts << '-I.'
-end
+RSpec::Core::RakeTask.new("spec")
 
 task :default => [:build]

--- a/fluent-plugin-sqs.gemspec
+++ b/fluent-plugin-sqs.gemspec
@@ -31,16 +31,16 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<fluentd>, ["~> 0.12.0"])
+      s.add_runtime_dependency(%q<fluentd>, [">= 0.12.0", "< 2"])
       s.add_runtime_dependency(%q<aws-sdk-v1>)
       s.add_runtime_dependency(%q<yajl-ruby>, ["~> 1.0"])
     else
-      s.add_dependency(%q<fluentd>, ["~> 0.12.0"])
+      s.add_dependency(%q<fluentd>, [">= 0.12.0", "< 2"])
       s.add_dependency(%q<aws-sdk-v1>)
       s.add_dependency(%q<yajl-ruby>, ["~> 1.0"])
     end
   else
-    s.add_dependency(%q<fluentd>, ["~> 0.12.0"])
+    s.add_dependency(%q<fluentd>, [">= 0.12.0", "< 2"])
     s.add_dependency(%q<aws-sdk-v1>)
     s.add_dependency(%q<yajl-ruby>, ["~> 1.0"])
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,6 @@ RSpec.configure do |config|
   require 'ostruct'
   require 'pry'
   require 'rr'
+  # prevent Test::Unit's AutoRunner from executing during RSpec's rake task
+  Test::Unit.run = true if defined?(Test::Unit) && Test::Unit.respond_to?(:run=)
 end


### PR DESCRIPTION
td-agent3 will ship with Fluentd v0.14 and Ruby 2.4.
With current dependency, msgpack v0.5.12 cannot install on Ruby 2.4 environment.
Fluentd v0.14 depends on msgpack 1.0.x which is solved "Interger Unification" problem in Ruby 2.4.