### PR TITLE
Use queue instance mock properly

### DIFF
--- a/spec/lib/fluent/plugin/out_sqs_spec.rb
+++ b/spec/lib/fluent/plugin/out_sqs_spec.rb
@@ -121,6 +121,7 @@ describe Fluent::SQSOutput do
     it 'send_messages to queue' do
       allow(Yajl).to receive(:dump).with(record) { body }
 
+      expect(driver.instance).to receive(:queue).twice.and_return("QUEUE_NAME")
       expect(subject.queue).to receive(:send_messages).with(entries: [{ id: kind_of(String), message_body: body, delay_seconds: 0 }])
 
       driver.emit(record).run


### PR DESCRIPTION
Otherwise, I've got the following error in spec:

```log

Failures:

  1) Fluent::SQSOutput#write send_messages to queue
     Failure/Error: resource.create_queue(queue_name: @queue_name)

     Aws::Errors::MissingCredentialsError:
       unable to sign request without credentials set
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/request_signer.rb:104:in `require_credentials'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/request_signer.rb:94:in `sign_authenticated_requests'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/request_signer.rb:87:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/helpful_socket_errors.rb:10:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/retry_errors.rb:89:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/sqs_queue_urls.rb:13:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/query/handler.rb:27:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/user_agent.rb:12:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/seahorse/client/plugins/endpoint.rb:41:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/param_validator.rb:21:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/idempotency_token.rb:18:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/seahorse/client/plugins/response_target.rb:21:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/seahorse/client/request.rb:70:in `send_request'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-core-2.10.2/lib/seahorse/client/base.rb:207:in `block (2 levels) in define_operation_methods'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-resources-2.10.2/lib/aws-sdk-resources/request.rb:24:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-resources-2.10.2/lib/aws-sdk-resources/operations.rb:41:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-resources-2.10.2/lib/aws-sdk-resources/operations.rb:87:in `call'
     # ./vendor/bundle/ruby/2.4.0/gems/aws-sdk-resources-2.10.2/lib/aws-sdk-resources/operation_methods.rb:19:in `block in add_operation'
     # ./lib/fluent/plugin/out_sqs.rb:49:in `queue'
     # ./spec/lib/fluent/plugin/out_sqs_spec.rb:124:in `block (3 levels) in <top (required)>'

Finished in 3.22 seconds (files took 0.62319 seconds to load)
32 examples, 1 failure
```