### PR TITLE
Add FIFO Queue config parameter

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -33,9 +33,13 @@ Read events from from amazon SQS.
       aws_sec_key {your_aws_secret_key}
 
       # following attibutes are optional
-    　
+
       create_queue {boolean}
       region {your_region}
+
+      # following attributes are required if you use FIFO queue
+
+      message_group_id {string}
 
       ### region list ###
       # Asia Pacific (Tokyo) [Default] : ap-northeast-1


### PR DESCRIPTION
Hi @ixixi .

I add **MessageGroupId** parameter to out_sqs plugin.
This parameter is required to FIFO queue.

> To send a message to a FIFO queue, type text into the Message Body, type the Message Group ID (required) and the Message Deduplication ID (required) and then choose Send Message.
https://aws.amazon.com/sqs/faqs/?nc1=h_ls

MessageDuplicationID is not set in this PR.
So it is required to set ContentBasedDeduplication `true` when creating SQS queue.