### PR TITLE
Use `SecureRandom.hex` instead of `generate_id`

### DIFF
--- a/lib/fluent/plugin/out_sqs.rb
+++ b/lib/fluent/plugin/out_sqs.rb
@@ -100,7 +100,8 @@ module Fluent::Plugin
                    "#{SQS_BATCH_SEND_MAX_SIZE} bytes.  " \
                    "(Truncated message: #{body[0..200]})"
         else
-          batch_records << { id: generate_id, message_body: body, delay_seconds: @delay_seconds }
+          id = "#{@tag_property_name}#{SecureRandom.hex(16)}"
+          batch_records << { id: id, message_body: body, delay_seconds: @delay_seconds }
         end
       end
 
@@ -110,11 +111,6 @@ module Fluent::Plugin
           queue.send_messages(entries: records.slice!(0..9))
         end
       end
-    end
-
-    def generate_id
-      unique_val = ((('a'..'z').to_a + (0..9).to_a)*3).shuffle[0,(rand(10).to_i)].join
-      @tag_property_name + Time.now.to_i.to_s + unique_val
     end
   end
 end


### PR DESCRIPTION
I have the same probrem with https://github.com/ixixi/fluent-plugin-sqs/pull/35

In the first place, plugin does not need to have implementation for Unique ID generation
In this case, plugin can use SecureRandom.

For your information, I benchmarked each performance.
SecureRandom is obviously safer and faster.

```
% ruby unique_id_bench.rb
Warming up --------------------------------------
        securerandom    54.085k i/100ms
         generate_id    11.633k i/100ms
Calculating -------------------------------------
        securerandom    658.520k (± 0.9%) i/s -      3.299M in   5.010460s
         generate_id    122.832k (± 1.3%) i/s -    616.549k in   5.020287s

Comparison:
        securerandom:   658519.5 i/s
         generate_id:   122831.7 i/s - 5.36x  slower
```

```ruby
require 'securerandom'
require 'benchmark/ips'

def generate_id
  unique_val = ((('a'..'z').to_a + (0..9).to_a)*3).shuffle[0,(rand(10).to_i)].join
  Time.now.to_i.to_s + unique_val
end

Benchmark.ips do |x|
  x.report("securerandom") { SecureRandom.hex(16) }
  x.report("generate_id") { generate_id }

  x.compare!
end
```