### PR TITLE
Fix exception handling (in_sqs.rb)

### DIFF
--- a/lib/fluent/plugin/in_sqs.rb
+++ b/lib/fluent/plugin/in_sqs.rb
@@ -59,9 +59,9 @@ module Fluent::Plugin
 
         router.emit(@tag, Fluent::Engine.now, record)
       end
-    rescue
-      log.error 'failed to emit or receive', error: $ERROR_INFO.to_s, error_class: $ERROR_INFO.class.to_s
-      log.warn_backtrace $ERROR_INFO.backtrace
+    rescue => ex
+      log.error 'failed to emit or receive', error: ex.to_s, error_class: ex.class
+      log.warn_backtrace ex.backtrace
     end
 
     private


### PR DESCRIPTION
## We found this:

```
2018-05-10 12:34:59 +0000 [error]: #0 Unexpected error raised. Stopping the timer.
 title=:in_sqs_run_periodic_timer
 error_class=NoMethodError
 error="undefined method `backtrace' for nil:NilClass"
```

This PR updates the exception handling to prevent exception inside rescue (and so prevent timer being stopped)

### Proof of concept in `irb`:

#### *Before:*

```
$ irb
irb(main):001:0> begin; puts File.join(nil, "hey"); rescue   # Cause some exception
irb(main):002:1> puts $ERROR_INFO.to_s
irb(main):003:1> puts $ERROR_INFO.backtrace
irb(main):004:1> end

NoMethodError: undefined method `backtrace' for nil:NilClass
	from (irb):3:in `rescue in irb_binding'
	from (irb):1
	from /usr/local/bin/irb:11:in `<main>'
irb(main):005:0> ## Exception inside rescue T_T
```

### *After:*

```
irb(main):001:0> begin; puts File.join(nil, "hey"); rescue => ex   # Cause some exception
irb(main):002:1> puts ex.to_s
irb(main):003:1> puts ex.backtrace
irb(main):004:1> end
no implicit conversion of nil into String
(irb):1:in `join'
(irb):1:in `irb_binding'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/workspace.rb:87:in `eval'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/workspace.rb:87:in `evaluate'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/context.rb:381:in `evaluate'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:493:in `block (2 levels) in eval_input'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:627:in `signal_status'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:490:in `block in eval_input'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/ruby-lex.rb:246:in `block (2 levels) in each_top_level_statement'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/ruby-lex.rb:232:in `loop'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/ruby-lex.rb:232:in `block in each_top_level_statement'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/ruby-lex.rb:231:in `catch'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb/ruby-lex.rb:231:in `each_top_level_statement'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:489:in `eval_input'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:430:in `block in run'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:429:in `catch'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:429:in `run'
/usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/irb.rb:385:in `start'
/usr/local/bin/irb:11:in `<main>'
=> nil
irb(main):005:0>  ## Successfully rescued
```

