### PR TITLE
Resolve Credentials issues and queue URL issues

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,25 +21,23 @@ Read events from from amazon SQS.
 
       type sqs
 
-      # url as https://sqs.us-west-2.amazonaws.com/123456789012/myqueue
-      sqs_url {queue_url}
-
-      # following attibute is required if you don't declare a sqs_url
-      queue_name {queue_instance_key}
+      # following attibute is required
+      queue_name {queue_name}
 
       # following attibutes are required if you don't use IAM Role nor export credentials to ENV
 
       aws_key_id {your_aws_key_id}
       aws_sec_key {your_aws_secret_key}
 
-      # following attibutes are optional
-
-      create_queue {boolean}
-      region {your_region}
-
       # following attributes are required if you use FIFO queue
 
       message_group_id {string}
+
+      # following attibutes are optional
+
+      create_queue {boolean}
+
+      region {your_region}
 
       ### region list ###
       # Asia Pacific (Tokyo) [Default] : ap-northeast-1
@@ -53,6 +51,7 @@ Read events from from amazon SQS.
       delay_seconds {delivery_delay_seconds}
 
       include_tag {boolean}
+
       tag_property_name {tag's property name in json}
 
 
@@ -66,7 +65,7 @@ Read events from from amazon SQS.
 
       # following attibutes are required
 
-      sqs_url {queue_url}
+      queue_name {queue_name}
 
       # following attibutes are required if you don't use IAM Role nor export credentials to ENV
 

--- a/lib/fluent/plugin/out_sqs.rb
+++ b/lib/fluent/plugin/out_sqs.rb
@@ -55,6 +55,9 @@ module Fluent::Plugin
       rescue Aws::SQS::Errors::NonExistentQueue => e
         if @create_queue
           sqs_url = client.create_queue(queue_name: @queue_name).queue_url
+        else
+          raise
+        end
       end
 
       @queue = Aws::SQS::Queue.new(


### PR DESCRIPTION
 * Related to https://github.com/ixixi/fluent-plugin-sqs/issues/39 and https://github.com/ixixi/fluent-plugin-sqs/pull/40, we avoid setting `Aws.config` because that is shared between all AWS SDK clients in use.

* Related to https://github.com/aws/aws-sdk-ruby/issues/1620, we avoid asking for `sqs_url` as a configuration option, because depending on the AWS SDK version you have, it may not be able to handle both formats of SQS URL that are in use currently e.g.
  - `https://{REGION}.queue.amazonaws.com/{ACCOUNT_ID}/{QUEUE_NAME}`
  - `https://sqs.{REGION}.amazonaws.com/{ACCOUNT_ID}/{QUEUE_NAME}`