### PR TITLE
Chore(lib/fluent/plugin/in_sqs.rb) Raw message

### DIFF
--- a/lib/fluent/plugin/in_sqs.rb
+++ b/lib/fluent/plugin/in_sqs.rb
@@ -1,5 +1,6 @@
 require 'fluent/plugin/input'
 require 'aws-sdk-sqs'
+require 'json'
 
 module Fluent::Plugin
   class SQSInput < Input
@@ -18,6 +19,7 @@ module Fluent::Plugin
     config_param :visibility_timeout, :integer, default: nil
     config_param :delete_message, :bool, default: false
     config_param :stub_responses, :bool, default: false
+    config_param :raw_message, :bool, default: false
 
     def configure(conf)
       super
@@ -53,7 +55,7 @@ module Fluent::Plugin
         wait_time_seconds: @wait_time_seconds,
         visibility_timeout: @visibility_timeout
       ).each do |message|
-        record = parse_message(message)
+        record = @raw_message ? parse_raw_message(message) : parse_message(message)
 
         message.delete if @delete_message
 
@@ -66,6 +68,10 @@ module Fluent::Plugin
 
     private
 
+    def parse_raw_message(message)
+      JSON.parse(message.body) rescue message.body.to_s 
+    end
+    
     def parse_message(message)
       {
         'body' => message.body.to_s,


### PR DESCRIPTION
Adding the parameter `raw_message`, and enabling as true in my fluent.conf, I can see the raw message, if it is a json is shown json and if it is a string is shown the string. Example below that it worked correctly.

Before correction:

```
{"body":"{\n\n \"application\": \"teste-portuga\",\n   \"environment\": \"teste-portuga\"\n}\n","receipt_handle":"AQEBdqji/Q+s4h5byM74e3HDU6MsPLMshdxNbU0ZoxG70QlHzWnT1hY01wiyUafLwtz/4oQpaXVuWMnd2CbYwWzSEmltfdjxYIJcwTkGGPdR/PxWBbitUyN7x/RQfb7YxLLNYEy6tbZSVQOGRnk79bx19fx6qA3i8Lzl5wdRk7Xj4xhuHoKBaqZKpkVkA5gKZtf8izmxpmFph3cj+6UwR367EtVpK0Q/x6cGP5/ToYZxKEANRcxpvnHQMEnISu7//YsFcxeV/CN2mvSLIj0fFCv3UVfqpsbUVLS4dxDVHs9ypGewCrqX8j0yiBvMefnY/ovEc9iaTvwl/0tsubxaOWckn5w1tD5Mz1zpplOL/lue6O0LCh5yuf5ZSl9VYdj9t0GsmqHywSa8WtIogpG7cLnSGg==","message_id":"7556e466-97d5-4feb-a056-9410878a5746","md5_of_body":"3606fb98abe1341bd47cadea430381d2","queue_url":"https://sqs.sa-east-1.amazonaws.com/620282384849/teste-portuga","sender_id":""}
```

After correction:

```
{"application":"teste-portuga","environment":"teste-portuga"}
```

Obs: this is my fluent.conf:

```
 <source>
    @type sqs
    tag "portuga"
    sqs_url "teste"
    aws_key_id xxxxxx
    aws_sec_key xxxxxx
    region "region"
    raw_message true
    delete_message 
  </source>
  <match portuga>
    @type stdout
    <format>
      @type "json"
    </format>
  </match>
```